### PR TITLE
chg: Make ci builds linux-only.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
     steps:
       - name: Checkout repository and submodules
         uses: actions/checkout@v2


### PR DESCRIPTION
Speed up CI builds by making them Linux-only.  Other operating systems will be tested during nightly builds.