### PR TITLE
chg: Populate cache during workspace init only

### DIFF
--- a/emscripten/private/emconfig.sdk
+++ b/emscripten/private/emconfig.sdk
@@ -4,3 +4,4 @@ LLVM_ROOT='{llvm_root}'
 BINARYEN_ROOT='{binaryen_root}'
 NODE_JS='node'
 CACHE='{cache}'
+FROZEN_CACHE=True


### PR DESCRIPTION
Set FROZEN_CACHE=True to ensure that we do not try to populate the emcc cache when building emcc_binaries or _libraries.